### PR TITLE
Use util encoding bridge from zed

### DIFF
--- a/src/FondOfCodeception/Lib/TransferFacadeFactory.php
+++ b/src/FondOfCodeception/Lib/TransferFacadeFactory.php
@@ -46,17 +46,16 @@ class TransferFacadeFactory
     }
 
     /**
-     * @throws
-     *
      * @return \Spryker\Zed\Kernel\Container
      */
     protected function createContainer(): Container
     {
         $container = new Container();
 
-        if(!defined('\Spryker\Zed\Transfer\TransferDependencyProvider::SYMFONY_FINDER') ||
-            !defined('\Spryker\Zed\Transfer\TransferDependencyProvider::SYMFONY_FILE_SYSTEM'))
-        {
+        if (
+            !defined('\Spryker\Zed\Transfer\TransferDependencyProvider::SYMFONY_FINDER') ||
+            !defined('\Spryker\Zed\Transfer\TransferDependencyProvider::SYMFONY_FILE_SYSTEM')
+        ) {
             return $container;
         }
 
@@ -84,7 +83,7 @@ class TransferFacadeFactory
      */
     protected function createTransferToUtilGlobServiceBridge(): TransferToUtilGlobServiceInterface
     {
-        return  new TransferToUtilGlobServiceBridge($this->createUtilGlobService());
+        return new TransferToUtilGlobServiceBridge($this->createUtilGlobService());
     }
 
     /**
@@ -119,7 +118,7 @@ class TransferFacadeFactory
 
                 $sourceDirectories[] = rtrim(APPLICATION_ROOT_DIR, DIRECTORY_SEPARATOR) . '/*/src/*/Shared/*/Transfer/';
                 $sourceDirectories[] = rtrim(APPLICATION_ROOT_DIR, DIRECTORY_SEPARATOR) . '/*/*/src/*/Shared/*/Transfer/';
-                
+
                 return $sourceDirectories;
             }
         };

--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -19,7 +19,7 @@ class Spryker extends Module
     protected $config = [
         SprykerConstants::CONFIG_GENERATE_TRANSFER => true,
         SprykerConstants::CONFIG_GENERATE_MAP_CLASSES => true,
-        SprykerConstants::CONFIG_SUPPORTED_SOURCE_IDENTIFIERS => ['page']
+        SprykerConstants::CONFIG_SUPPORTED_SOURCE_IDENTIFIERS => ['page'],
     ];
 
     /**


### PR DESCRIPTION
While search-elasticsearch is < 1.8.0, we need to use the encoding bridge for zed instead of shared