### PR TITLE
fix config boolean values check

### DIFF
--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -64,11 +64,11 @@ class Spryker extends Module
 
         $this->initEnvironment();
 
-        if ($this->config[SprykerConstants::CONFIG_GENERATE_TRANSFER]) {
+        if (trim($this->config[SprykerConstants::CONFIG_GENERATE_TRANSFER]) === true) {
             $this->generateTransfer();
         }
 
-        if ($this->config[SprykerConstants::CONFIG_GENERATE_MAP_CLASSES]) {
+        if (trim($this->config[SprykerConstants::CONFIG_GENERATE_MAP_CLASSES]) === true) {
             $this->generateMapClasses();
         }
     }


### PR DESCRIPTION
- the boolean value is always true evaluated because there is a space in the value. For Example   generate_transfer: false is evaluated as  generate_transfer: " ", which is true