### PR TITLE
fix config check:

### DIFF
--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -64,11 +64,11 @@ class Spryker extends Module
 
         $this->initEnvironment();
 
-        if (trim($this->config[SprykerConstants::CONFIG_GENERATE_TRANSFER]) == true) {
+        if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_TRANSFER]) {
             $this->generateTransfer();
         }
 
-        if (trim($this->config[SprykerConstants::CONFIG_GENERATE_MAP_CLASSES]) == true) {
+        if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_MAP_CLASSES]) {
             $this->generateMapClasses();
         }
     }


### PR DESCRIPTION
- use '==' instead of '===', because in the configuration file the 'true' is translated as '1'