### PR TITLE
Allow PHP 7.4 preloading in propel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "autoload": {
     "psr-4": {
       "Generated\\": "src/Generated",
+      "Orm\\": "src/Orm",
       "FondOfCodeception\\": "src/FondOfCodeception",
       "Propel\\Generator\\Behavior\\Synchronization\\": "src/Propel/Generator/Behavior/Synchronization"
     }

--- a/src/FondOfCodeception/Lib/PropelFacadeFactory.php
+++ b/src/FondOfCodeception/Lib/PropelFacadeFactory.php
@@ -141,7 +141,7 @@ class PropelFacadeFactory
              */
             public function getSchemaDirectory()
             {
-                return SprykerConstants::SCHEMA_DIRECTORY;
+                return SprykerConstants::PROPEL_SCHEMA_DIRECTORY;
             }
         };
     }

--- a/src/FondOfCodeception/Lib/TransferFacadeFactory.php
+++ b/src/FondOfCodeception/Lib/TransferFacadeFactory.php
@@ -188,7 +188,7 @@ class TransferFacadeFactory
              */
             public function getSchemaDirectory(): string
             {
-                return SprykerConstants::SCHEMA_DIRECTORY;
+                return SprykerConstants::PROPEL_SCHEMA_DIRECTORY;
             }
         };
     }

--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -5,6 +5,7 @@ namespace FondOfCodeception\Module;
 use Codeception\Configuration;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Module;
+use Exception;
 use FondOfCodeception\Lib\NullLoggerFactory;
 use FondOfCodeception\Lib\PropelFacadeFactory;
 use FondOfCodeception\Lib\SearchFacadeFactory;
@@ -75,7 +76,6 @@ class Spryker extends Module
 
         if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_PROPEL_CLASSES]) {
             $this->generatePropelClasses();
-            $this->loadDatabase();
         }
 
         if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_TRANSFER]) {
@@ -100,25 +100,31 @@ class Spryker extends Module
         $this->debug('Merging and coping schema files...');
         $propelFacade->copySchemaFilesToTargetDirectory();
 
-        $this->debug('Generating popel classes...');
-        (new Process([
+        $configFile = APPLICATION_VENDOR_DIR . '/fond-of-codeception/spryker/propel.yml';
+
+        if (!file_exists($configFile)) {
+            $configFile = APPLICATION_ROOT_DIR . '/propel.yml';
+        }
+
+        $modelBuildCommand = [
             APPLICATION_VENDOR_DIR . '/bin/propel',
             'model:build',
             '--config-dir',
-            APPLICATION_VENDOR_DIR . '/fond-of-codeception/spryker/propel.yml',
-        ]))->run();
-    }
+            $configFile
+        ];
 
-    /**
-     * @return void
-     */
-    protected function loadDatabase(): void
-    {
-        $propelDatabaseConfigurationFile = SprykerConstants::PROPEL_DATABSE_CONFIGURATION_FILE;
-
-        if (file_exists($propelDatabaseConfigurationFile)) {
-            require_once($propelDatabaseConfigurationFile);
+        $this->debug('Generating propel classes...');
+        try {
+            (new Process(
+                array_merge(
+                    $modelBuildCommand,
+                    ['--loader-script-dir', SprykerConstants::PROPEL_LOADER_SCRIPT_DIRECTORY]
+                )
+            ))->mustRun();
+        } catch (Exception $exception) {
+            (new Process($modelBuildCommand))->mustRun();
         }
+
     }
 
     /**

--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -75,6 +75,7 @@ class Spryker extends Module
 
         if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_PROPEL_CLASSES]) {
             $this->generatePropelClasses();
+            $this->loadDatabase();
         }
 
         if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_TRANSFER]) {
@@ -106,6 +107,18 @@ class Spryker extends Module
             '--config-dir',
             APPLICATION_VENDOR_DIR . '/fond-of-codeception/spryker/propel.yml',
         ]))->run();
+    }
+
+    /**
+     * @return void
+     */
+    protected function loadDatabase(): void
+    {
+        $propelDatabaseConfigurationFile = SprykerConstants::PROPEL_DATABSE_CONFIGURATION_FILE;
+
+        if (file_exists($propelDatabaseConfigurationFile)) {
+            require_once($propelDatabaseConfigurationFile);
+        }
     }
 
     /**

--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -110,7 +110,7 @@ class Spryker extends Module
             APPLICATION_VENDOR_DIR . '/bin/propel',
             'model:build',
             '--config-dir',
-            $configFile
+            $configFile,
         ];
 
         $this->debug('Generating propel classes...');
@@ -124,7 +124,6 @@ class Spryker extends Module
         } catch (Exception $exception) {
             (new Process($modelBuildCommand))->mustRun();
         }
-
     }
 
     /**

--- a/src/FondOfCodeception/Module/SprykerConstants.php
+++ b/src/FondOfCodeception/Module/SprykerConstants.php
@@ -6,8 +6,8 @@ interface SprykerConstants
 {
     public const STORE = 'UNIT';
 
-    public const SCHEMA_DIRECTORY = APPLICATION_SOURCE_DIR . '/Orm/Propel/Schema';
-    public const PROPEL_DATABSE_CONFIGURATION_FILE = APPLICATION_ROOT_DIR . '/generated-conf/loadDatabase.php';
+    public const PROPEL_SCHEMA_DIRECTORY = APPLICATION_SOURCE_DIR . '/Orm/Propel/Schema';
+    public const PROPEL_LOADER_SCRIPT_DIRECTORY = APPLICATION_SOURCE_DIR . '/Orm/Propel/generated-conf';
 
     public const CONFIG_GENERATE_TRANSFER = 'generate_transfer';
     public const CONFIG_GENERATE_MAP_CLASSES = 'generate_map_classes';

--- a/src/FondOfCodeception/Module/SprykerConstants.php
+++ b/src/FondOfCodeception/Module/SprykerConstants.php
@@ -7,6 +7,7 @@ interface SprykerConstants
     public const STORE = 'UNIT';
 
     public const SCHEMA_DIRECTORY = APPLICATION_SOURCE_DIR . '/Orm/Propel/Schema';
+    public const PROPEL_DATABSE_CONFIGURATION_FILE = APPLICATION_ROOT_DIR . '/generated-conf/loadDatabase.php';
 
     public const CONFIG_GENERATE_TRANSFER = 'generate_transfer';
     public const CONFIG_GENERATE_MAP_CLASSES = 'generate_map_classes';


### PR DESCRIPTION
- add new parameter `--loader-script-dir` to build model command
- add Orm classes to autoload section
- throw exception if propel classes could not be generated

Description for preloading problem with PHP 7.4:
https://github.com/propelorm/Propel2/wiki/Exception-Target:-Loading-the-database