### PR TITLE
Feature: add IDE autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ This module allows developers to test spryker modules isolated.
             generate_transfer: true|false # Default is true
             generate_map_classes: true|false # Default is true
             generate_propel_classes: true|false # Default is true
+            generate_ide_auto_completion: true|false # Default is true
             supported_source_identifiers: [string] # Default is ['page']
+            ide_auto_completion_source_directories: [string => string] # Default is empty but it got merged with Spryker default paths
     ...
     ```
 
@@ -33,6 +35,7 @@ This module allows developers to test spryker modules isolated.
 * Generate (entity)transfer classes
 * Generate propel classes
 * Generate map classes
+* Generate ide auto completion
 * Initialize environment (constants like APPLICATION_ROOT_DIR will be created)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,23 +12,24 @@ This module allows developers to test spryker modules isolated.
     composer require --dev fond-of-codeception/spryker
     ```
 
-2. Enable module in `codeception.yml`:
-    ``` yml
-    ...
-    modules:
-      enabled:
-        - ...
-        - \FondOfCodeception\Module\Spryker
-      config:
-        \FondOfCodeception\Module\Spryker:
-            generate_transfer: true|false # Default is true
-            generate_map_classes: true|false # Default is true
-            generate_propel_classes: true|false # Default is true
-            generate_ide_auto_completion: true|false # Default is true
-            supported_source_identifiers: [string] # Default is ['page']
-            ide_auto_completion_source_directories: [string => string] # Default is empty but it got merged with Spryker default paths
-    ...
-    ```
+   2. Enable module in `codeception.yml`:
+       ``` yml
+       ...
+       modules:
+         enabled:
+           - ...
+           - \FondOfCodeception\Module\Spryker
+         config:
+           \FondOfCodeception\Module\Spryker:
+               generate_transfer: true|false # Default is true
+               generate_map_classes: true|false # Default is true
+               generate_propel_classes: true|false # Default is true
+               generate_ide_auto_completion: true|false # Default is true
+               supported_source_identifiers: [string] # Default is ['page']
+               ide_auto_completion_source_directories: [string => string] # Default is empty but it got merged with Spryker default paths
+                    './bundles/*/src/': '*/*/' # Example value with wildcard
+       ...
+       ```
 
 ## Features
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "spryker/search": "^8.0.0",
     "spryker/search-elasticsearch": "^1.0.0",
     "spryker/synchronization-behavior": "^1.0.0",
-    "spryker/transfer": "^3.1.1"
+    "spryker/transfer": "^3.1.1",
+    "spryker/development": "^3.34"
   },
   "require-dev": {
     "spryker/code-sniffer": "*"

--- a/src/FondOfCodeception/Lib/DevelopmentFactory.php
+++ b/src/FondOfCodeception/Lib/DevelopmentFactory.php
@@ -11,6 +11,7 @@ use Spryker\Zed\Development\DevelopmentDependencyProvider;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 use Spryker\Zed\Kernel\Container;
 use Symfony\Component\Finder\Finder;
+use Throwable;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -30,7 +31,7 @@ class DevelopmentFactory
     }
 
     /**
-     * @return \Spryker\Zed\Transfer\Business\TransferFacadeInterface
+     * @return \Spryker\Zed\Development\Business\DevelopmentFacadeInterface
      */
     public function create(): DevelopmentFacadeInterface
     {
@@ -147,7 +148,7 @@ class DevelopmentFactory
             /**
              * @var array<string>
              */
-            protected $ideAutoCompletionSourceDirectories;
+            protected array $ideAutoCompletionSourceDirectories;
 
             /**
              * @param array<string> $ideAutoCompletionSourceDirectories
@@ -162,10 +163,16 @@ class DevelopmentFactory
              */
             public function getIdeAutoCompletionSourceDirectoryGlobPatterns(): array
             {
-                return [
-                    APPLICATION_VENDOR_DIR . '/*/*/src/' => '*/*/',
-                    ...$this->ideAutoCompletionSourceDirectories,
-                ];
+                try {
+                    $ideAutoCompletionSourceDirectories = parent::getIdeAutoCompletionSourceDirectoryGlobPatterns();
+                } catch (Throwable $e) {
+                    $ideAutoCompletionSourceDirectories = [APPLICATION_VENDOR_DIR . '/*/*/src/' => '*/*/'];
+                }
+
+                return array_merge(
+                    $ideAutoCompletionSourceDirectories,
+                    $this->ideAutoCompletionSourceDirectories,
+                );
             }
         };
     }

--- a/src/FondOfCodeception/Lib/DevelopmentFactory.php
+++ b/src/FondOfCodeception/Lib/DevelopmentFactory.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace FondOfCodeception\Lib;
+
+use FondOfCodeception\Module\SprykerConstants;
+use Spryker\Zed\Development\Business\DevelopmentBusinessFactory;
+use Spryker\Zed\Development\Business\DevelopmentFacade;
+use Spryker\Zed\Development\Business\DevelopmentFacadeInterface;
+use Spryker\Zed\Development\DevelopmentConfig;
+use Spryker\Zed\Development\DevelopmentDependencyProvider;
+use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
+use Spryker\Zed\Kernel\Container;
+use Symfony\Component\Finder\Finder;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+class DevelopmentFactory
+{
+    /**
+     * @var array
+     */
+    protected array $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return \Spryker\Zed\Transfer\Business\TransferFacadeInterface
+     */
+    public function create(): DevelopmentFacadeInterface
+    {
+        $developmentFacade = new DevelopmentFacade();
+
+        $developmentFacade->setFactory($this->createDevelopmentBusinessFactory());
+
+        return $developmentFacade;
+    }
+
+    /**
+     * @return \Spryker\Zed\Kernel\Business\AbstractBusinessFactory
+     */
+    protected function createDevelopmentBusinessFactory(): AbstractBusinessFactory
+    {
+        $developmentBusinessFactory = new DevelopmentBusinessFactory();
+
+        $developmentBusinessFactory->setContainer($this->createContainer());
+        $developmentBusinessFactory->setConfig($this->createDevelopmentConfig());
+
+        return $developmentBusinessFactory;
+    }
+
+    /**
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function createContainer(): Container
+    {
+        $container = new Container();
+
+        $container = $this->addTwigEnvironmentToContainer($container);
+        $container = $this->addTwigLoaderFilesystemToContainer($container);
+        $container = $this->addFinderToContainer($container);
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addTwigEnvironmentToContainer(Container $container): Container
+    {
+        if (!defined('\Spryker\Zed\Development\DevelopmentDependencyProvider::TWIG_ENVIRONMENT')) {
+            return $container;
+        }
+
+        if (!method_exists($container, 'set')) {
+            $container[DevelopmentDependencyProvider::TWIG_ENVIRONMENT] = new Environment(
+                new FilesystemLoader(),
+            );
+
+            return $container;
+        }
+
+        $container->set(DevelopmentDependencyProvider::TWIG_ENVIRONMENT, new Environment(
+            new FilesystemLoader(),
+        ));
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addTwigLoaderFilesystemToContainer(Container $container): Container
+    {
+        if (!defined('\Spryker\Zed\Development\DevelopmentDependencyProvider::TWIG_LOADER_FILESYSTEM')) {
+            return $container;
+        }
+
+        if (!method_exists($container, 'set')) {
+            $container[DevelopmentDependencyProvider::TWIG_LOADER_FILESYSTEM] = new FilesystemLoader();
+
+            return $container;
+        }
+
+        $container->set(DevelopmentDependencyProvider::TWIG_LOADER_FILESYSTEM, new FilesystemLoader());
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addFinderToContainer(Container $container): Container
+    {
+        if (!defined('\Spryker\Zed\Development\DevelopmentDependencyProvider::FINDER')) {
+            return $container;
+        }
+
+        if (!method_exists($container, 'set')) {
+            $container[DevelopmentDependencyProvider::FINDER] = new Finder();
+
+            return $container;
+        }
+
+        $container->set(DevelopmentDependencyProvider::FINDER, new Finder());
+
+        return $container;
+    }
+
+    /**
+     * @return \Spryker\Zed\Development\DevelopmentConfig
+     */
+    protected function createDevelopmentConfig(): DevelopmentConfig
+    {
+        return new class ($this->config[SprykerConstants::CONFIG_IDE_AUTO_COMPLETION_SOURCE_DIRECTORIES]) extends DevelopmentConfig {
+            /**
+             * @var array<string>
+             */
+            protected $ideAutoCompletionSourceDirectories;
+
+            /**
+             * @param array<string> $ideAutoCompletionSourceDirectories
+             */
+            public function __construct(array $ideAutoCompletionSourceDirectories)
+            {
+                $this->ideAutoCompletionSourceDirectories = $ideAutoCompletionSourceDirectories;
+            }
+
+            /**
+             * @return array<string>
+             */
+            public function getIdeAutoCompletionSourceDirectoryGlobPatterns(): array
+            {
+                return [
+                    APPLICATION_VENDOR_DIR . '/*/*/src/' => '*/*/',
+                    ...$this->ideAutoCompletionSourceDirectories,
+                ];
+            }
+        };
+    }
+}

--- a/src/FondOfCodeception/Module/Spryker.php
+++ b/src/FondOfCodeception/Module/Spryker.php
@@ -6,6 +6,7 @@ use Codeception\Configuration;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Module;
 use Exception;
+use FondOfCodeception\Lib\DevelopmentFactory;
 use FondOfCodeception\Lib\NullLoggerFactory;
 use FondOfCodeception\Lib\PropelFacadeFactory;
 use FondOfCodeception\Lib\SearchFacadeFactory;
@@ -23,7 +24,9 @@ class Spryker extends Module
         SprykerConstants::CONFIG_GENERATE_TRANSFER => true,
         SprykerConstants::CONFIG_GENERATE_MAP_CLASSES => true,
         SprykerConstants::CONFIG_GENERATE_PROPEL_CLASSES => true,
+        SprykerConstants::CONFIG_GENERATE_IDE_AUTO_COMPLETION => true,
         SprykerConstants::CONFIG_SUPPORTED_SOURCE_IDENTIFIERS => ['page'],
+        SprykerConstants::CONFIG_IDE_AUTO_COMPLETION_SOURCE_DIRECTORIES => [],
     ];
 
     /**
@@ -52,6 +55,11 @@ class Spryker extends Module
     protected ?LoggerInterface $nullLogger = null;
 
     /**
+     * @var \FondOfCodeception\Lib\DevelopmentFactory
+     */
+    protected DevelopmentFactory $developmentFacadeFactory;
+
+    /**
      * @param \Codeception\Lib\ModuleContainer $moduleContainer
      * @param array|null $config
      */
@@ -63,6 +71,7 @@ class Spryker extends Module
         $this->searchFacadeFactory = new SearchFacadeFactory($this->config);
         $this->propelFacadeFactory = new PropelFacadeFactory();
         $this->transferFacadeFactory = new TransferFacadeFactory();
+        $this->developmentFacadeFactory = new DevelopmentFactory($this->config);
     }
 
     /**
@@ -84,6 +93,10 @@ class Spryker extends Module
 
         if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_MAP_CLASSES]) {
             $this->generateMapClasses();
+        }
+
+        if ((bool)$this->config[SprykerConstants::CONFIG_GENERATE_IDE_AUTO_COMPLETION]) {
+            $this->generateIdeAutocompletion();
         }
     }
 
@@ -167,6 +180,21 @@ class Spryker extends Module
         } else {
             $searchFacade->generateSourceMap($nullLogger);
         }
+    }
+
+    /**
+     * @return void
+     */
+    protected function generateIdeAutocompletion(): void
+    {
+        $developmentFacade = $this->developmentFacadeFactory->create();
+
+        $developmentFacade->generateClientIdeAutoCompletion();
+        $developmentFacade->generateGlueIdeAutoCompletion();
+        $developmentFacade->generateServiceIdeAutoCompletion();
+        $developmentFacade->generateYvesIdeAutoCompletion();
+        $developmentFacade->generateZedIdeAutoCompletion();
+        $developmentFacade->generateGlueBackendIdeAutoCompletion();
     }
 
     /**

--- a/src/FondOfCodeception/Module/SprykerConstants.php
+++ b/src/FondOfCodeception/Module/SprykerConstants.php
@@ -43,4 +43,14 @@ interface SprykerConstants
      * @var string
      */
     public const CONFIG_SUPPORTED_SOURCE_IDENTIFIERS = 'supported_source_identifiers';
+
+    /**
+     * @var string
+     */
+    public const CONFIG_GENERATE_IDE_AUTO_COMPLETION = 'generate_ide_auto_completion';
+
+    /**
+     * @var string
+     */
+    public const CONFIG_IDE_AUTO_COMPLETION_SOURCE_DIRECTORIES = 'ide_auto_completion_source_directories';
 }

--- a/tests/FondOfCodeception/Lib/DevelopmentFactoryTest.php
+++ b/tests/FondOfCodeception/Lib/DevelopmentFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FondOfCodeception\Lib;
+
+use Codeception\Test\Unit;
+use FondOfCodeception\Module\SprykerConstants;
+use Spryker\Zed\Development\Business\DevelopmentFacade;
+
+class DevelopmentFactoryTest extends Unit
+{
+    /**
+     * @var \FondOfCodeception\Lib\DevelopmentFactory
+     */
+    protected DevelopmentFactory $developmentFactory;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->developmentFactory = new DevelopmentFactory([
+            SprykerConstants::CONFIG_IDE_AUTO_COMPLETION_SOURCE_DIRECTORIES => [],
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreate(): void
+    {
+        $developmentFacade = $this->developmentFactory->create();
+
+        static::assertInstanceOf(DevelopmentFacade::class, $developmentFacade);
+    }
+}

--- a/tests/FondOfCodeception/Lib/DevelopmentFactoryTest.php
+++ b/tests/FondOfCodeception/Lib/DevelopmentFactoryTest.php
@@ -18,6 +18,8 @@ class DevelopmentFactoryTest extends Unit
      */
     protected function _before(): void
     {
+        defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', getcwd());
+
         $this->developmentFactory = new DevelopmentFactory([
             SprykerConstants::CONFIG_IDE_AUTO_COMPLETION_SOURCE_DIRECTORIES => [],
         ]);


### PR DESCRIPTION
Add options to create IDE autocompletion files for Spryker locator. 
It helps phpstan to recognize the correct type of locator.
It is also handy for monorepos to use there IDE autocompletion.

New config values:

```yaml
generate_ide_auto_completion: true # true|false Default is true
ide_auto_completion_source_directories: # [string => string] Default is empty but it got merged with Spryker default paths
  './bundles/*/src/': '*/*/'
```