### PR TITLE
Create Tech Stack docs

### DIFF
--- a/techstack.md
+++ b/techstack.md
@@ -1,0 +1,76 @@
+<!--
+--- Readme.md Snippet without images Start ---
+## Tech Stack
+spryker-community/codeception-spryker is built on the following main stack:
+- [PHP](http://www.php.net/) – Languages
+- [Codeception](http://codeception.com/) – Testing Frameworks
+- [GitHub Actions](https://github.com/features/actions) – Continuous Integration
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet without images End ---
+
+--- Readme.md Snippet with images Start ---
+## Tech Stack
+spryker-community/codeception-spryker is built on the following main stack:
+- <img width='25' height='25' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'/> [PHP](http://www.php.net/) – Languages
+- <img width='25' height='25' src='https://img.stackshare.io/service/2301/fQkiPzLo_400x400.jpg' alt='Codeception'/> [Codeception](http://codeception.com/) – Testing Frameworks
+- <img width='25' height='25' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'/> [GitHub Actions](https://github.com/features/actions) – Continuous Integration
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet with images End ---
+-->
+<div align="center">
+
+# Tech Stack File
+![](https://img.stackshare.io/repo.svg "repo") [spryker-community/codeception-spryker](https://github.com/spryker-community/codeception-spryker)![](https://img.stackshare.io/public_badge.svg "public")
+<br/><br/>
+|4<br/>Tools used|11/09/23 <br/>Report generated|
+|------|------|
+</div>
+
+## <img src='https://img.stackshare.io/languages.svg'/> Languages (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'>
+  <br>
+  <sub><a href="http://www.php.net/">PHP</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+## <img src='https://img.stackshare.io/devops.svg'/> DevOps (3)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/2301/fQkiPzLo_400x400.jpg' alt='Codeception'>
+  <br>
+  <sub><a href="http://codeception.com/">Codeception</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+<td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1046/git.png' alt='Git'>
+  <br>
+  <sub><a href="http://git-scm.com/">Git</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+<td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'>
+  <br>
+  <sub><a href="https://github.com/features/actions">GitHub Actions</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+<br/>
+<div align='center'>
+
+Generated via [Stack File](https://github.com/apps/stack-file)

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,0 +1,50 @@
+repo_name: spryker-community/codeception-spryker
+report_id: ba1f63889503941d9d24040e73a293a7
+repo_type: Public
+timestamp: '2023-11-09T17:23:07+00:00'
+requested_by: daniel-rose
+provider: github
+branch: master
+detected_tools_count: 4
+tools:
+- name: PHP
+  description: A popular general-purpose scripting language that is especially suited
+    to web development
+  website_url: http://www.php.net/
+  open_source: true
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg
+  detection_source: Repo Metadata
+- name: Codeception
+  description: Elegant and Efficient Testing for PHP
+  website_url: http://codeception.com/
+  open_source: false
+  hosted_saas: true
+  category: Build, Test, Deploy
+  sub_category: Testing Frameworks
+  image_url: https://img.stackshare.io/service/2301/fQkiPzLo_400x400.jpg
+  detection_source: composer.json
+  last_updated_by: Daniel Rose
+  last_updated_on: 2022-12-13 15:20:33.000000000 Z
+- name: Git
+  description: Fast, scalable, distributed revision control system
+  website_url: http://git-scm.com/
+  open_source: true
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Version Control System
+  image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source: Repo Metadata
+- name: GitHub Actions
+  description: Automate your workflow from idea to production
+  website_url: https://github.com/features/actions
+  open_source: false
+  hosted_saas: true
+  category: Build, Test, Deploy
+  sub_category: Continuous Integration
+  image_url: https://img.stackshare.io/service/11563/actions.png
+  detection_source: ".github/workflows/main.yml"
+  last_updated_by: Daniel Rose
+  last_updated_on: 2022-12-13 15:20:33.000000000 Z


### PR DESCRIPTION
PR to add tech stack documentation to allow anyone to easily see what is being used in this repo without digging through config files. Two files are being added: techstack.yml and techstack.md. The techstack.yml file contains data on all the tools being used in this repo. The techstack.md file is derived from the YML file and displays the tech stack data in Markdown.